### PR TITLE
[CRAI-302] Fix crash on onboarding

### DIFF
--- a/CarRecognition/Source Files/Modules/Onboarding/Root/Animation Player/OnboardingAnimationPlayer.swift
+++ b/CarRecognition/Source Files/Modules/Onboarding/Root/Animation Player/OnboardingAnimationPlayer.swift
@@ -62,6 +62,7 @@ internal final class OnboardingAnimationPlayer {
     private func removeTimeObserver() {
         guard let playerTimeObserver = playerTimeObserver else { return }
         playerViewController.player?.removeTimeObserver(playerTimeObserver)
+        self.playerTimeObserver = nil
     }
     
     private func addTimeObserver(for time: CMTime) {


### PR DESCRIPTION
### Ticket
[CRAI-302](https://netguru.atlassian.net/browse/CRAI-302)


### Task Description
Quickly changing pages on onboarding causes crash. It is fixed.