### PR TITLE
[CRAI-308] Unify model results' normalization algorithm with Android version

### DIFF
--- a/CarRecognition/Source Files/Application/ApplicationConstants.swift
+++ b/CarRecognition/Source Files/Application/ApplicationConstants.swift
@@ -25,4 +25,23 @@ struct Constants {
         static let initialAnimationDelayInMilliseconds = 400
     }
     
+    /// Constants used in recognition process.
+    struct Recognition {
+        
+        ///Thresholds for the recognition confidence values.
+        struct Threshold {
+            
+            /// Minimum threshold filtering the results at the beginning.
+            static let minimum: Float = 0.1
+            
+            /// Threshold stating whether the recognition of the car is in progress.
+            static let neededToShowProgress: Float = 0.4
+        
+            /// Confidence needed to pin the AR label.
+            static let neededToPinARLabel: Float = 0.75
+        }
+        
+        /// Number of last results that should be normalized.
+        static let normalizationCount = 5
+    }
 }

--- a/CarRecognition/Source Files/Common/Models/CarARConfiguration.swift
+++ b/CarRecognition/Source Files/Common/Models/CarARConfiguration.swift
@@ -24,12 +24,6 @@ internal struct CarARConfiguration {
     /// Place for doing the hit test
     let pointForHitTest = CGPoint(x: 0.5, y: 0.5)
     
-    /// Minimum confidence nedded to pin the label
-    let neededConfidenceToPinLabel = 0.96
-    
-    /// Number of last values that should be normalized
-    let normalizationCount = 10
-    
     init() {
         #if ENV_DEVELOPMENT
             nodeShift = NodeShift(depth: 0, elevation: 0)

--- a/CarRecognition/Source Files/Common/Models/RecognitionResult.swift
+++ b/CarRecognition/Source Files/Common/Models/RecognitionResult.swift
@@ -28,7 +28,11 @@ internal struct RecognitionResult: CustomStringConvertible {
     }
     
     let recognition: Recognition
+    
     let confidence: Float
+    
+    /// Label returned by a model.
+    let label: String
     
     /// Initializes the object from given parameters
     ///
@@ -38,6 +42,7 @@ internal struct RecognitionResult: CustomStringConvertible {
     ///   - carsDataService: Data Service with cars
     init?(label: String, confidence: Float, carsDataService: CarsDataService) {
         self.confidence = confidence
+        self.label = label
         if let car = carsDataService.map(classifierLabel: label) {
             recognition = .car(car)
         } else if label == "other car" {

--- a/CarRecognition/Source Files/Common/Services/CarClassificationService.swift
+++ b/CarRecognition/Source Files/Common/Services/CarClassificationService.swift
@@ -76,7 +76,8 @@ internal final class CarClassificationService {
         else {
             return
         }
-        let recognitionResult = classifications.compactMap { RecognitionResult(label: $0.identifier, confidence: $0.confidence, carsDataService: carsDataService) }
+        let recognitionResult = classifications.filter { $0.confidence > Constants.Recognition.Threshold.minimum }
+                                            .compactMap { RecognitionResult(label: $0.identifier, confidence: $0.confidence, carsDataService: carsDataService) }
         completionHandler?(recognitionResult)
     }
 }

--- a/CarRecognition/Source Files/Common/Services/CarClassificationService.swift
+++ b/CarRecognition/Source Files/Common/Services/CarClassificationService.swift
@@ -76,8 +76,9 @@ internal final class CarClassificationService {
         else {
             return
         }
-        let recognitionResult = classifications.filter { $0.confidence > Constants.Recognition.Threshold.minimum }
-                                            .compactMap { RecognitionResult(label: $0.identifier, confidence: $0.confidence, carsDataService: carsDataService) }
+        let recognitionResult = classifications
+            .filter { $0.confidence > Constants.Recognition.Threshold.minimum }
+            .compactMap { RecognitionResult(label: $0.identifier, confidence: $0.confidence, carsDataService: carsDataService) }
         completionHandler?(recognitionResult)
     }
 }

--- a/CarRecognition/Source Files/Common/Services/InputNormalizationService.swift
+++ b/CarRecognition/Source Files/Common/Services/InputNormalizationService.swift
@@ -33,8 +33,8 @@ internal final class InputNormalizationService {
     /// - Returns: Normalized RecognitionResult value.
     func normalizeConfidence(from recognitionData: [RecognitionResult]) -> RecognitionResult? {
         let sortedResults = recognitionData.sorted(by: { $0.confidence > $1.confidence })
-        let resultsNumberNeeded = numberOfValuesNeeded - recognitionResults.count
-        let resultsNeeded = sortedResults.prefix(resultsNumberNeeded)
+        let numberOfResultsNeeded = numberOfValuesNeeded - recognitionResults.count
+        let resultsNeeded = sortedResults.prefix(numberOfResultsNeeded)
         recognitionResults.append(contentsOf: resultsNeeded)
         guard recognitionResults.count == numberOfValuesNeeded else { return nil }
         let averageConfidencesForEachLabel: [String: Float] = dictionaryWithValuesSum(from: recognitionResults).mapValues { countAverage($0) }

--- a/CarRecognition/Source Files/Common/Services/InputNormalizationService.swift
+++ b/CarRecognition/Source Files/Common/Services/InputNormalizationService.swift
@@ -6,49 +6,53 @@
 
 internal final class InputNormalizationService {
     
-    private let numberOfValuesToAverageCalculation: Int
-    private lazy var normalizationValue = 1.0 / Double(numberOfValuesToAverageCalculation)
-    private lazy var lastValues = [Double](repeating: 0.0, count: numberOfValuesToAverageCalculation)
+    /// Number of recognition results needed for normalization to begin.
+    private let numberOfValuesNeeded: Int
+    
+    /// Storage of recognition results to be normilized.
+    private var recognitionResults: [RecognitionResult] = []
+    
+    /// Indicating whether is ready for performing normalization.
+    private var isReadyToNormalize: Bool {
+        return recognitionResults.count == numberOfValuesNeeded
+    }
+    
+    private let carsDataService: CarsDataService
     
     /// Initializes the normalizer
     ///
-    /// - Parameter numberOfValues: Number of last saved values that will be used for normalization. Must be greater than 0.
-    init(numberOfValues: Int) {
+    /// - Parameters:
+    ///   - numberOfValues: Number of last saved values that will be used for normalization. Must be greater than 0.
+    ///   - carsDataService: Data Service with cars.
+    init(numberOfValues: Int, carsDataService: CarsDataService) {
         guard numberOfValues > 0 else {
             fatalError("Cannot initialize normalizer with value \(numberOfValues). It must be greater than 0")
         }
-        self.numberOfValuesToAverageCalculation = numberOfValues
+        self.numberOfValuesNeeded = numberOfValues
+        self.carsDataService = carsDataService
     }
     
-    /// Normalizes given value
+    /// Normalizes given value.
     ///
-    /// - Parameter value: Value to be normalized
-    /// - Returns: Normalized value
-    func normalize(value: Double) -> Double {
-        lastValues.insert(value, at: 0)
-        lastValues.removeLast()
-        
-        var average = 0.0
-        lastValues.forEach { average += $0 * normalizationValue }
-        return average
+    /// - Parameter recognitionData: Recognition Results to be normalized.
+    /// - Returns: Normalized RecognitionResult value.
+    func normalizeConfidence(from recognitionData: [RecognitionResult]) -> RecognitionResult? {
+        let sortedResults = recognitionData.sorted(by: { $0.confidence > $1.confidence })
+        let resultsNumberNeeded = numberOfValuesNeeded - self.recognitionResults.count
+        self.recognitionResults.append(contentsOf: sortedResults.prefix(resultsNumberNeeded))
+        guard isReadyToNormalize else { return nil }
+        let sumOfConfidencesForEachLabel: [String: [Float]] = recognitionResults.reduce(into: [:]) { (counts, result) in
+                                                counts[result.label, default: []].append(result.confidence)
+                                            }
+        let averageConfidencesForEachLabel: [String: Float] = sumOfConfidencesForEachLabel.mapValues {
+                                                $0.reduce(0, {$0 + $1}) / Float($0.count)
+                                            }
+        guard let bestResult = averageConfidencesForEachLabel.sorted(by: { $0.value > $1.value }).first else { return nil }
+        return RecognitionResult(label: bestResult.0, confidence: bestResult.1, carsDataService: carsDataService)
     }
     
-    /// Normalizes given value
-    ///
-    /// - Parameter recognition: Recognition Result to be normalized
-    /// - Returns: Normalized confidence value
-    func normalizeConfidence(from recognitionResult: RecognitionResult) -> Double {
-        let confidenceForNormalization: Double
-        if case RecognitionResult.Recognition.notCar = recognitionResult.recognition {
-            confidenceForNormalization = 0
-        } else {
-            confidenceForNormalization = Double(recognitionResult.confidence)
-        }
-        return normalize(value: confidenceForNormalization)
-    }
-    
-    /// Resets the normalizer
+    /// Resets the normalizer.
     func reset() {
-        lastValues = [Double](repeating: 0.0, count: numberOfValuesToAverageCalculation)
+        recognitionResults = []
     }
 }

--- a/CarRecognition/Source Files/Common/Views/DetectionViewfinderView.swift
+++ b/CarRecognition/Source Files/Common/Views/DetectionViewfinderView.swift
@@ -22,10 +22,9 @@ internal final class DetectionViewfinderView: View, ViewSetupable {
     ///
     /// - Parameters:
     ///     - result: Result of the detection
-    ///     - normalizedConfidence: Normalized confidence of the model
-    func update(to result: RecognitionResult, normalizedConfidence: Double) {
-        viewfinderAnimationView.animationProgress = CGFloat(normalizedConfidence)
-        guard normalizedConfidence > 0.5 else {
+    func update(to result: RecognitionResult) {
+        viewfinderAnimationView.animationProgress = CGFloat(result.confidence)
+        guard result.confidence > Constants.Recognition.Threshold.neededToShowProgress else {
             informationSwitcherView.switchLabelsWithText(Localizable.Recognition.pointCameraAtCar)
             return
         }

--- a/CarRecognition/Source Files/Modules/Recognition/Root/AugmentedRealityViewController/AugmentedRealityViewController.swift
+++ b/CarRecognition/Source Files/Modules/Recognition/Root/AugmentedRealityViewController/AugmentedRealityViewController.swift
@@ -66,8 +66,8 @@ internal final class AugmentedRealityViewController: TypedViewController<Augment
     /// Updates the detection viewfinder with given state
     ///
     /// - Parameter result: Result to be set
-    func updateDetectionViewfinder(to result: RecognitionResult, normalizedConfidence: Double) {
-        customView.detectionViewfinderView.update(to: result, normalizedConfidence: normalizedConfidence)
+    func updateDetectionViewfinder(to result: RecognitionResult) {
+        customView.detectionViewfinderView.update(to: result)
     }
     
     /// Tries to add augmented reality pin to the car in 3D world

--- a/CarRecognitionTests/Tests/Models/CarARConfigurationTests.swift
+++ b/CarRecognitionTests/Tests/Models/CarARConfigurationTests.swift
@@ -33,16 +33,14 @@ final class CarARConfigurationTests: XCTestCase {
 
     func testConfigurationParameters() {
         XCTAssertEqual(sut.pointForHitTest, DesiredParameters.pointForHitTest, "Point for hit test should be equal to \(DesiredParameters.pointForHitTest)")
-        XCTAssertEqual(sut.neededConfidenceToPinLabel, DesiredParameters.neededConfidenceToPinLabel, "Needed confidence to pin the label should be equal to \(DesiredParameters.neededConfidenceToPinLabel)")
-        XCTAssertEqual(sut.normalizationCount, DesiredParameters.normalizationCount, "Normalization count should be equal to \(DesiredParameters.normalizationCount)")
     }
 
     func testEnvironmentVariables() {
         #if ENV_TESTS
             XCTAssertEqual(sut.nodeShift, DesiredParameters.nodeShift, "Node shift should be equal to \(DesiredParameters.nodeShift)")
-            XCTAssertEqual(sut.minimumDistanceFromDevice, DesiredParameters.minimumDistanceFromDevice, "Miinmum distance from device should be equal to \(DesiredParameters.minimumDistanceFromDevice)")
-            XCTAssertEqual(sut.minimumDistanceBetweenNodes, DesiredParameters.minimumDistanceBetweenNodes, "Mininmum distance between nodes should be equal to \(DesiredParameters.minimumDistanceBetweenNodes)")
-            XCTAssertEqual(sut.maximumDistanceFromDevice, DesiredParameters.maximumDistanceFromDevice, "Maximum distance from device should be equal to \(DesiredParameters.maximumDistanceFromDevice)")
+            XCTAssertEqual(sut.minimumDistanceFromDevice, DesiredParameters.minimumDistanceFromDevice, "Minimumal distance from device should be equal to \(DesiredParameters.minimumDistanceFromDevice)")
+            XCTAssertEqual(sut.minimumDistanceBetweenNodes, DesiredParameters.minimumDistanceBetweenNodes, "Minimumal distance between nodes should be equal to \(DesiredParameters.minimumDistanceBetweenNodes)")
+            XCTAssertEqual(sut.maximumDistanceFromDevice, DesiredParameters.maximumDistanceFromDevice, "Maximal distance from device should be equal to \(DesiredParameters.maximumDistanceFromDevice)")
         #endif
     }
 }

--- a/CarRecognitionTests/Tests/Models/CarARConfigurationTests.swift
+++ b/CarRecognitionTests/Tests/Models/CarARConfigurationTests.swift
@@ -38,8 +38,8 @@ final class CarARConfigurationTests: XCTestCase {
     func testEnvironmentVariables() {
         #if ENV_TESTS
             XCTAssertEqual(sut.nodeShift, DesiredParameters.nodeShift, "Node shift should be equal to \(DesiredParameters.nodeShift)")
-            XCTAssertEqual(sut.minimumDistanceFromDevice, DesiredParameters.minimumDistanceFromDevice, "Minimumal distance from device should be equal to \(DesiredParameters.minimumDistanceFromDevice)")
-            XCTAssertEqual(sut.minimumDistanceBetweenNodes, DesiredParameters.minimumDistanceBetweenNodes, "Minimumal distance between nodes should be equal to \(DesiredParameters.minimumDistanceBetweenNodes)")
+            XCTAssertEqual(sut.minimumDistanceFromDevice, DesiredParameters.minimumDistanceFromDevice, "Minimal distance from device should be equal to \(DesiredParameters.minimumDistanceFromDevice)")
+            XCTAssertEqual(sut.minimumDistanceBetweenNodes, DesiredParameters.minimumDistanceBetweenNodes, "Minimal distance between nodes should be equal to \(DesiredParameters.minimumDistanceBetweenNodes)")
             XCTAssertEqual(sut.maximumDistanceFromDevice, DesiredParameters.maximumDistanceFromDevice, "Maximal distance from device should be equal to \(DesiredParameters.maximumDistanceFromDevice)")
         #endif
     }

--- a/CarRecognitionTests/Tests/Models/RecognitionResultTests.swift
+++ b/CarRecognitionTests/Tests/Models/RecognitionResultTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class RecognitionResultTests: XCTestCase {
     
-    private struct Labels {
+    struct Labels {
         static let otherCar = "other car"
         static let notCar = "not a car"
         static let unknown = "unknown label"

--- a/CarRecognitionTests/Tests/Services/InputNormalizationServiceTests.swift
+++ b/CarRecognitionTests/Tests/Services/InputNormalizationServiceTests.swift
@@ -11,51 +11,45 @@ final class InputNormalizationServiceTests: XCTestCase {
     
     var sut: InputNormalizationService!
     
-    func testInitialValueWith30LastValues() {
-        sut = InputNormalizationService(numberOfValues: 30)
-        let result = sut.normalize(value: 0.3)
-        XCTAssertEqual(result, 0.01, accuracy: 0.01)
+    var carsDataService: CarsDataService!
+    
+    override func setUp() {
+        super.setUp()
+        carsDataService = CarsDataService()
+        sut = InputNormalizationService(numberOfValues: 3, carsDataService: carsDataService)
     }
     
-    func testInitialValueWith10LastValues() {
-        sut = InputNormalizationService(numberOfValues: 10)
-        let result = sut.normalize(value: 0.3)
-        XCTAssertEqual(result, 0.03, accuracy: 0.01)
-    }
-    
-    func test15thWith30LastValues() {
-        sut = InputNormalizationService(numberOfValues: 30)
-        var result = 0.0
-        for _ in 0..<15 {
-            result = sut.normalize(value: 0.5)
+    func testWithOneValue() {
+        guard let recognitionResult = RecognitionResult(label: RecognitionResultTests.Labels.notCar, confidence: 0.75, carsDataService: carsDataService) else {
+            XCTFail("Recognition result can't be nil")
+            return
         }
-        XCTAssertEqual(result, 0.25, accuracy: 0.01)
+        let result = sut.normalizeConfidence(from: [recognitionResult])
+        XCTAssertNil(result, "Result should be nil if the recognition results count is less then number of values for a normalization")
     }
     
-    func test30thWith30LastValues() {
-        sut = InputNormalizationService(numberOfValues: 30)
-        var result = 0.0
-        for _ in 0..<30 {
-            result = sut.normalize(value: 0.5)
+    func testAfterAddingValues() {
+        testWithOneValue()
+        guard let firstResult = RecognitionResult(label: RecognitionResultTests.Labels.otherCar, confidence: 0.2, carsDataService: carsDataService),
+            let secondResult = RecognitionResult(label: RecognitionResultTests.Labels.otherCar, confidence: 0.6, carsDataService: carsDataService) else {
+            XCTFail("Recognition results can't be nil")
+            return
         }
-        XCTAssertEqual(result, 0.5, accuracy: 0.01)
+        let result = sut.normalizeConfidence(from: [firstResult, secondResult])
+        XCTAssertEqual(result?.confidence, 0.75, "Result confidence should be the highest average from all of the previous results")
+        XCTAssertEqual(result?.label, RecognitionResultTests.Labels.notCar, "Result confidence should be the highest average from all of the previous results")
     }
     
-    func test5thWith10LastValues() {
-        sut = InputNormalizationService(numberOfValues: 10)
-        var result = 0.0
-        for _ in 0..<5 {
-            result = sut.normalize(value: 0.5)
+    func testWithThreeValuesOutOfThree() {
+        guard let firstResult = RecognitionResult(label: RecognitionResultTests.Labels.notCar, confidence: 0.7, carsDataService: carsDataService),
+            let secondResult = RecognitionResult(label: RecognitionResultTests.Labels.notCar, confidence: 0.5, carsDataService: carsDataService),
+            let thirdResult = RecognitionResult(label: RecognitionResultTests.Labels.otherCar, confidence: 0.2, carsDataService: carsDataService) else {
+            XCTFail("Recognition results can't be nil")
+            return
         }
-        XCTAssertEqual(result, 0.25, accuracy: 0.01)
+        let result = sut.normalizeConfidence(from: [firstResult, secondResult, thirdResult])
+        XCTAssertEqual(result?.confidence, 0.6, "Result confidence should be the highest average")
+        XCTAssertEqual(result?.label, RecognitionResultTests.Labels.notCar, "Result confidence should be the highest average")
     }
     
-    func test10thWith10LastValues() {
-        sut = InputNormalizationService(numberOfValues: 10)
-        var result = 0.0
-        for _ in 0..<10 {
-            result = sut.normalize(value: 0.5)
-        }
-        XCTAssertEqual(result, 0.5, accuracy: 0.01)
-    }
 }


### PR DESCRIPTION
### Ticket
[CRAI-308](https://netguru.atlassian.net/browse/CRAI-308)


### Task Description
<!-- What should and what actually happens. -->
The algorithm, which normalizes the output values was completely different from the Android one. In this PR it's unified.
Now it:
1. Takes last 5 recognition results (or waits for 5 results to be gathered as they can be returned from multiple calls to the ML model).
2. Counts the confidence's average (arithmetic mean) within each label returned by a model.
3. Returns the result with the highest average.

Additionally, the thresholds values were improved and their logic was a bit changed.
The unneeded showing of the pinning AR Label Error was removed.
